### PR TITLE
add dependency in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "node-red-contrib-kafka-manager",
   "version": "0.2.8",
   "description": "Node-RED implements Kafka manager with associand associated .",
-  "dependencies": {},
+  "dependencies": {
+    "kafka-node": "*"
+  },
   "devDependencies": {},
   "scripts": {
     "test": "echo \\\"Error: no test specified\\\" && exit 1"


### PR DESCRIPTION
Hi @peterprib ,

I am not sure why you have not set kafka-node as a dependency in the package.
By adding it you shouldn't need anymore to install other palette or manually install the dependency.

If I missed the reason please let me know.