### PR TITLE
Improve SASL credentials configuration with checkbox

### DIFF
--- a/kafkaManager/kafkaBroker.html
+++ b/kafkaManager/kafkaBroker.html
@@ -60,6 +60,10 @@
  		        </div>
 		 	</div>
 
+            <div class="form-row">
+                <input type="checkbox" id="node-config-input-useCredentials" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-config-input-useCredentials" style="width: auto">Use Credentials (SASL plain)</label>
+            </div>
 		    <div class="form-row">
 		        <label for="node-config-input-user"><i class="icon-bookmark"></i> User</label>
 		        <input type="text" id="node-config-input-user">
@@ -140,7 +144,8 @@
 			checkInterval: {value:10, required:false,validate:RED.validators.number()},
 			tls: {type:"tls-config",required: false},
 			selfSign: {value: false,required: false},
-			usetls: {value: false}
+			usetls: {value: false},
+            useCredentials: {value: false}
 	    },
         credentials: {
             user: {type:'text'},
@@ -221,6 +226,10 @@
   		oneditsave: function() {
             if (!$("#node-config-input-usetls").is(':checked')) {
                 $("#node-config-input-tls").val("");
+            }
+            if (!$("#node-config-input-useCredentials").is(':checked')) {
+                $("#node-config-input-user").val("");
+                $("#node-config-input-password").val("");
             }
            	let inputs,node=this;
         	node.hosts=[];

--- a/kafkaManager/kafkaBroker.js
+++ b/kafkaManager/kafkaBroker.js
@@ -318,7 +318,8 @@ module.exports = function (RED) {
         autoConnect: (node.autoConnect || 'true') === 'true',
         idleConnection: node.idleConnection || 5,
         reconnectOnIdle: (node.reconnectOnIdle || 'true') === 'true',
-        maxAsyncRequests: node.maxAsyncRequests || 10
+        maxAsyncRequests: node.maxAsyncRequests || 10,
+        useCredentials: node.useCredentials || false
       }, o)
    	  if(logger.active) logger.send({label:'getKafkaClient',usetls:node.usetls,options:options});
       if(node.usetls) {
@@ -336,8 +337,8 @@ module.exports = function (RED) {
     		  node.error("get node tls "+node.tls+" failed, error:"+e);
     	  }
       }
-      if (node.credentials.has_password) {
-    	if(logger.active) logger.send({label:'getKafkaClient node credentials has password, note sasl mechanism is plain'});
+      if (options.useCredentials) {
+    	if(logger.active) logger.send({label:'getKafkaClient node has configured credentials, note sasl mechanism is plain'});
         options.sasl = {
           mechanism: 'plain',
           username: this.credentials.user,


### PR DESCRIPTION
I managed to improve the configuration of the credentials for the SASL plain text mechanism, with a checkbox. 
I also removed the conditional line 
`if (node.credentials.has_password) {`
That wasn't working as expected and therefore credentials were not being set.
Now the useCredentials variable from the checkbox is used to evaluate whether to authenticate with SASL or not.