### PR TITLE
Added forgotten function assignment

### DIFF
--- a/kafkaManager/kafkaBroker.js
+++ b/kafkaManager/kafkaBroker.js
@@ -321,6 +321,7 @@ module.exports = function (RED) {
       connect: connect,
       sendMsg:sendMsg,
       setState: setState,
+      closeNode: closeNode,
       stateUp: [],
       stateDown: [],
       onStateUp: []


### PR DESCRIPTION
The closeNode function was not assigned to KafkaBrokerNode and that caused error in kafkaConsumer's code
```node.close = (okCallback,errCallback) => node.brokerNode.closeNode(node,okCallback,errCallback);```