### PR TITLE
Use relative path for the button command

### DIFF
--- a/kafkaManager/kafkaConsumer.html
+++ b/kafkaManager/kafkaConsumer.html
@@ -237,7 +237,7 @@
 				function sendCommand(element,action) {
 					const nodeName="Kafka Consumer";
 					$(element).dialog("close");
-					$.get( "/KafkaConsumer/"+node.id+"/"+action )
+					$.get( "KafkaConsumer/"+node.id+"/"+action )
 					.done(function( json ) {
 					  	RED.notify(node._(nodeName+" signal success",{label:label}),{type:"success",id:"Load Injector"});
 					}).fail(function( jqXHR, textStatus, error ) {


### PR DESCRIPTION
Relative path allows button to work both in root (example.com) or a path (example.com/node-red) mode.